### PR TITLE
Minor fixes and worldtask

### DIFF
--- a/src/RockBridge.cpp
+++ b/src/RockBridge.cpp
@@ -6,6 +6,7 @@
 #include "RockBridge.hpp"
 
 #include <gazebo/ModelTask.hpp>
+#include <gazebo/WorldTask.hpp>
 
 #include <std/typekit/Plugin.hpp>
 #include <std/transports/corba/TransportPlugin.hpp>
@@ -27,6 +28,7 @@
 #include <rtt/extras/SequentialActivity.hpp>
 #include <rtt/transports/corba/ApplicationServer.hpp>
 #include <rtt/transports/corba/TaskContextServer.hpp>
+
 
 using namespace gazebo;
 
@@ -74,11 +76,11 @@ void RockBridge::worldCreated(std::string const& worldName)
 {
     gzmsg << "RockBridge: initializing world: " << worldName << std::endl;
 
-	physics::WorldPtr world = physics::get_world(worldName);
+    physics::WorldPtr world = physics::get_world(worldName);
     if (!world)
     {
-            gzerr << "RockBridge: cannot find world " << worldName << std::endl;
-            return;
+        gzerr << "RockBridge: cannot find world " << worldName << std::endl;
+        return;
     }
 
 	int environment = GROUND;
@@ -88,6 +90,11 @@ void RockBridge::worldCreated(std::string const& worldName)
 		environment = UNDERWATER; 
 		gzmsg << "RockBridge: underwater world detected. " << std::endl;
 	}	
+
+    WorldTask* world_task = new WorldTask();
+    world_task->setGazeboWorld(world);
+    setupTaskActivity(world_task);
+    tasks.push_back(world_task);
 		    
     typedef physics::Model_V Model_V;
     Model_V model_list = world->GetModels();

--- a/src/RockBridge.cpp
+++ b/src/RockBridge.cpp
@@ -22,6 +22,8 @@
 #include <gazebo/transports/typelib/TransportPlugin.hpp>
 #include <gazebo/transports/mqueue/TransportPlugin.hpp>
 
+#include <rtt/transports/corba/ApplicationServer.hpp>
+#include <rtt/transports/corba/TaskContextServer.hpp>
 
 using namespace gazebo;
 
@@ -30,6 +32,7 @@ using namespace gazebo;
 void RockBridge::Load(int _argc , char** _argv)
 {
 	RTT::corba::ApplicationServer::InitOrb(_argc, _argv);
+    RTT::corba::TaskContextServer::ThreadOrb(ORO_SCHED_OTHER, RTT::os::LowestPriority, 0);
 	
 	// Import typekits to allow RTT convert the types used by the components
 	RTT::types::TypekitRepository::Import(new orogen_typekits::stdTypekitPlugin);
@@ -187,7 +190,8 @@ RockBridge::~RockBridge()
 	tasks.clear();
 	
 	worlds.clear();
-//    RTT::corba::TaskContextServer::ShutdownOrb();
-//    RTT::corba::TaskContextServer::DestroyOrb();	
+
+    RTT::corba::TaskContextServer::ShutdownOrb();
+    RTT::corba::TaskContextServer::DestroyOrb();	
 }
 //======================================================================================

--- a/src/RockBridge.hpp
+++ b/src/RockBridge.hpp
@@ -12,22 +12,22 @@
 #include <gazebo/physics/physics.hh>
 #include <gazebo/common/common.hh>
 #include <gazebo/common/Plugin.hh>
-// Rock Headers
-#include <rtt/types/TypekitRepository.hpp>
-#include <rtt/transports/corba/TaskContextServer.hpp>
-#include <rtt/TaskContext.hpp>
-#include <rtt/Activity.hpp>
-//#include <rtt/extras/SlaveActivity.hpp>
 
 #define GROUND 0
 #define UNDERWATER 1
 
-namespace gazebo{
-	class ModelTask; 
+namespace RTT
+{
+    class TaskContext;
+    namespace base
+    {
+        class ActivityInterface;
+    }
 }
 
 namespace gazebo
 {
+    class ModelTask; 
 	class RockBridge: public SystemPlugin
 	{
 		public:
@@ -43,18 +43,16 @@ namespace gazebo
 			void createTask(gazebo::physics::WorldPtr, gazebo::physics::ModelPtr,int); 
 			void updateBegin(gazebo::common::UpdateInfo const& info);
 			void updateEnd();
+            void setupTaskActivity(RTT::TaskContext* task);
 
-			gazebo::ModelTask* task;
 			std::vector<event::ConnectionPtr> eventHandler;
 
+            typedef std::vector<RTT::TaskContext*> Tasks;
+            Tasks tasks;
+			typedef std::vector<RTT::base::ActivityInterface*> Activities;
 			typedef std::vector<gazebo::physics::WorldPtr> WorldContainer; 
 			WorldContainer worlds; 
 
-			typedef std::vector<gazebo::ModelTask*> ModelTasks;
-			ModelTasks tasks;
-			
-//			typedef std::vector<RTT::extras::SlaveActivity*> Activities;
-			typedef std::vector<RTT::Activity*> Activities;
 			Activities activities;
 	};
 	

--- a/src/RockBridge.hpp
+++ b/src/RockBridge.hpp
@@ -28,6 +28,8 @@ namespace RTT
 namespace gazebo
 {
     class ModelTask; 
+    class WorldTask;
+
 	class RockBridge: public SystemPlugin
 	{
 		public:


### PR DESCRIPTION
This creates a WorldTask per announced world, and makes use of the SequentialActivity
to trigger the tasks instead of calling updateModel manually

Corresponding PR on simulation-orogen-gazebo: Brazilian-Institute-of-Robotics/simulation-orogen-gazebo#2 
