### PR TITLE
Syskit Integration

### DIFF
--- a/bindings/ruby/CMakeLists.txt
+++ b/bindings/ruby/CMakeLists.txt
@@ -1,0 +1,2 @@
+rock_add_ruby_package(rock_gazebo)
+

--- a/bindings/ruby/lib/rock_gazebo.rb
+++ b/bindings/ruby/lib/rock_gazebo.rb
@@ -1,0 +1,9 @@
+
+# The toplevel namespace for rock_gazebo
+#
+# You should describe the basic idea about rock_gazebo here
+require 'utilrb/logger'
+module RockGazebo
+    extend Logger::Root('RockGazebo', Logger::WARN)
+end
+

--- a/bindings/ruby/lib/rock_gazebo/orogen_model_from_sdf_world.rb
+++ b/bindings/ruby/lib/rock_gazebo/orogen_model_from_sdf_world.rb
@@ -1,0 +1,30 @@
+module RockGazebo
+    # Creation of an oroGen deployment model representing what the
+    # rock-gazebo plugin would do from a SDF world
+    #
+    # @param [String] name the name that should be used as deployment name
+    # @param [SDF::World] world the SDF world that we have to represent
+    # @param [OroGen::Loaders::Base] loader the oroGen loader that we should use
+    #   to create the tasks
+    # @return [OroGen::Spec::Deployment]
+    def self.orogen_model_from_sdf_world(name, world, options = Hash.new)
+        options = validate_options options,
+            loader: Orocos.default_loader,
+            period: 0.01
+
+        project = OroGen::Spec::Project.new(options[:loader])
+        project.using_task_library 'rock_gazebo'
+        deployment = project.deployment name
+
+        period = options.fetch(:period)
+        deployment.task("gazebo:#{world.name}", "rock_gazebo::WorldTask").
+            periodic(period)
+        world.each_model do |model|
+            deployment.task("gazebo:#{world.name}:#{model.name}", "rock_gazebo::ModelTask").
+                periodic(period)
+        end
+
+        deployment
+    end
+end
+

--- a/bindings/ruby/lib/rock_gazebo/syskit.rb
+++ b/bindings/ruby/lib/rock_gazebo/syskit.rb
@@ -1,0 +1,10 @@
+require 'rock_gazebo/orogen_model_from_sdf_world'
+require 'sdf'
+require 'orocos'
+require 'syskit'
+require 'rock_gazebo/syskit/world'
+require 'rock_gazebo/syskit/world_manager'
+
+module RockGazebo
+    extend Logger::Root('RockGazebo', Logger::WARN)
+end

--- a/bindings/ruby/lib/rock_gazebo/syskit.rb
+++ b/bindings/ruby/lib/rock_gazebo/syskit.rb
@@ -4,7 +4,12 @@ require 'orocos'
 require 'syskit'
 require 'rock_gazebo/syskit/world'
 require 'rock_gazebo/syskit/world_manager'
+require 'rock_gazebo/syskit/configuration_extension'
 
 module RockGazebo
     extend Logger::Root('RockGazebo', Logger::WARN)
+
+    module Syskit
+        include Logger::Hierarchy
+    end
 end

--- a/bindings/ruby/lib/rock_gazebo/syskit/configuration_extension.rb
+++ b/bindings/ruby/lib/rock_gazebo/syskit/configuration_extension.rb
@@ -1,0 +1,35 @@
+module RockGazebo
+    module Syskit
+        module ConfigurationExtension
+            def use_gazebo_world(*path)
+                Roby.app.find_dirs('data', 'models', order: :specific_first, all: true).each do |path|
+                    if !SDF::XML.model_path.include?(path)
+                        SDF::XML.model_path.unshift path
+                    end
+                end
+
+                full_path = File.expand_path(File.join(*path))
+                if !File.exists?(full_path)
+                    full_path = Roby.app.find_file(*path, order: :specific_first) ||
+                        Roby.app.find_file('data', 'gazebo', 'worlds', *path, order: :specific_first)
+
+                    if !full_path
+                        raise ArgumentError, "cannot find #{File.join(*path)}"
+                    end
+                end
+
+                # Add the process manager if needed
+                if !has_process_server?('gazebo')
+                    register_process_server('gazebo', WorldManager.new(app.default_loader), 'logs')
+                end
+
+                world_manager = process_server_for('gazebo')
+                orogen = world_manager.register_world(full_path)
+                use_deployment(orogen, on: 'gazebo')
+            end
+        end
+
+        ::Syskit::RobyApp::Configuration.include ConfigurationExtension
+    end
+end
+

--- a/bindings/ruby/lib/rock_gazebo/syskit/world.rb
+++ b/bindings/ruby/lib/rock_gazebo/syskit/world.rb
@@ -84,15 +84,19 @@ module RockGazebo
                 deployed_tasks[task_name] ||= name_service.get(task_name)
             end
 
-            def kill(wait = true, status = ProcessManager::Status.new(:exit_code => 0))
+            def kill(wait = true, status = WorldManager::Status.new(:exit_code => 0))
                 deployed_tasks.each_value do |task|
-                    task.stop
-                    task.cleanup
+                    if task.rtt_state == :RUNNING
+                        task.stop
+                    end
+                    if task.rtt_state == :STOPPED
+                        task.cleanup
+                    end
                 end
                 dead!(status)
             end
 
-            def dead!(status = ProcessManager::Status.new(:exit_code => 0))
+            def dead!(status = WorldManager::Status.new(:exit_code => 0))
                 @alive = false
                 if world_manager
                     world_manager.dead_deployment(name, status)

--- a/bindings/ruby/lib/rock_gazebo/syskit/world.rb
+++ b/bindings/ruby/lib/rock_gazebo/syskit/world.rb
@@ -1,0 +1,113 @@
+module RockGazebo
+    module Syskit
+        class World < Orocos::ProcessBase
+            # The {WorldManager} object which created this World object
+            #
+            # If non-nil, the object's #dead_deployment will be called when self is
+            # stopped
+            #
+            # @return [#dead_deployment,nil]
+            attr_reader :world_manager
+
+            # The set of deployed tasks
+            #
+            # @return [{String=>TaskContext}] mapping from the deployed task name as
+            #   defined in {model} to the actual {Orocos::TaskContext}
+            attr_reader :deployed_tasks
+
+            # The host on which this process' tasks run
+            #
+            # @return [String]
+            attr_reader :host_id
+
+            # Whether the tasks in this process are running on the same machine than
+            # the ruby process
+            #
+            # This is always true as ruby tasks are instanciated inside the ruby
+            # process
+            #
+            # @return [Boolean]
+            def on_localhost?; host_id == 'localhost' end
+
+            # The PID of the process in which the tasks run
+            #
+            # This is always Process.pid as ruby tasks are instanciated inside the ruby
+            # process
+            #
+            # @return [Integer]
+            attr_reader :pid
+
+            # The name service object which should be used to resolve the tasks
+            attr_reader :name_service
+
+            # Creates a new object managing the tasks that represent a single gazebo world
+            #
+            # @param [nil,#dead_deployment] world_manager the world manager
+            #   which created this process. If non-nil, its #dead_deployment method
+            #   will be called when {stop} is called
+            # @param [String] name the process name
+            # @param [OroGen::Spec::Deployment] model the deployment model
+            def initialize(world_manager, name, model, options = Hash.new)
+                @world_manager = world_manager
+                @deployed_tasks = Hash.new
+                options = Kernel.validate_options options,
+                    name_service: Orocos.name_service
+                @name_service = options[:name_service]
+                @host_id = options[:host_id]
+                super(name, model)
+            end
+
+            # "Starts" this world
+            #
+            # This does nothing. Connectivity to expected tasks is done in
+            # {wait_running}
+            #
+            # @return [void]
+            def spawn(options = Hash.new)
+                deployed_tasks.clear
+                @alive = true
+            end
+
+            # Waits for the tasks to be ready
+            #
+            # This is a no-op as the tasks get resolved in #spawn
+            def wait_running(blocking = false)
+                # Just access the world task as a cheap check
+                world_task = model.task_activities.find { |t| t.task_model.name == 'rock_gazebo::WorldTask' }
+                world_task = task(world_task.name)
+                true
+            rescue Orocos::NotFound
+                false
+            end
+
+            def task(task_name)
+                deployed_tasks[task_name] ||= name_service.get(task_name)
+            end
+
+            def kill(wait = true, status = ProcessManager::Status.new(:exit_code => 0))
+                deployed_tasks.each_value do |task|
+                    task.stop
+                    task.cleanup
+                end
+                dead!(status)
+            end
+
+            def dead!(status = ProcessManager::Status.new(:exit_code => 0))
+                @alive = false
+                if world_manager
+                    world_manager.dead_deployment(name, status)
+                end
+            end
+
+            def join
+                raise NotImplementedError, "World#join is not implemented"
+            end
+
+            # True if the process is running. This is an alias for running?
+            def alive?; @alive end
+            # True if the process is running. This is an alias for alive?
+            def running?; @alive end
+        end
+    end
+end
+

--- a/bindings/ruby/lib/rock_gazebo/syskit/world_manager.rb
+++ b/bindings/ruby/lib/rock_gazebo/syskit/world_manager.rb
@@ -1,0 +1,126 @@
+require 'orocos/ruby_tasks/process'
+
+module RockGazebo
+    module Syskit
+        class WorldManager
+            # Exception raised if one attempts to do name mappings in a gazebo
+            # world manager
+            class NameMappingsForbidden < ArgumentError; end
+
+            class Status
+                def initialize(options = Hash.new)
+                    options = Kernel.validate_options options,
+                        :exit_code => nil,
+                        :signal => nil
+                    @exit_code = options[:exit_code]
+                    @signal = options[:signal]
+                end
+                def stopped?; false end
+                def exited?; !@exit_code.nil? end
+                def exitstatus; @exit_code end
+                def signaled?; !@signal.nil? end
+                def termsig; @signal end
+                def stopsig; end
+                def success?; exitstatus == 0 end
+            end
+
+            attr_reader :worlds
+            attr_reader :loader
+            attr_reader :terminated_worlds
+
+            def initialize(loader = Orocos.default_loader)
+                @loader = loader
+                @worlds = Hash.new
+                @terminated_worlds = Hash.new
+            end
+
+            def disconnect
+            end
+
+            def register_world(path, world_name = nil)
+                worlds = SDF::Root.load(path).each_world.to_a
+                if world_name
+                    world = worlds.find { |w| w.name == world_name }
+                    if !world
+                        raise ArgumentError, "cannot find a world named #{world_name} in #{path}"
+                    end
+                elsif worlds.size == 1
+                    world = worlds.first
+                elsif worlds.empty?
+                    raise ArgumentError, "no worlds declared in #{path}"
+                else
+                    raise ArgumentError, "more than one world declared in #{path}, select one explicitely by providing the world_name argument"
+                end
+
+                model = RockGazebo.orogen_model_from_sdf_world("gazebo_world_#{world.name}", world, loader: loader)
+                register_deployment_model(model)
+            end
+
+            def register_deployment_model(model)
+                loader.register_deployment_model(model)
+            end
+
+            def start(name, deployment_name = name, name_mappings = Hash.new, options = Hash.new)
+                model = if deployment_name.respond_to?(:to_str)
+                            loader.deployment_model_from_name(deployment_name)
+                        else deployment_name
+                        end
+                if worlds[name]
+                    raise ArgumentError, "#{name} is already started in #{self}"
+                end
+
+                prefix_mappings, options =
+                    Orocos::ProcessBase.resolve_prefix_option(options, model)
+                name_mappings = prefix_mappings.merge(name_mappings)
+                name_mappings.each do |from, to|
+                    if from != to
+                        raise NameMappingsForbidden, "cannot do name mapping in gazebo support"
+                    end
+                end
+
+                gazebo_world = World.new(self, name, model)
+                gazebo_world.spawn
+                worlds[name] = gazebo_world
+            end
+
+            # Requests that the process server moves the log directory at +log_dir+
+            # to +results_dir+
+            def save_log_dir(log_dir, results_dir)
+            end
+
+            # Creates a new log dir, and save the given time tag in it (used later
+            # on by save_log_dir)
+            def create_log_dir(log_dir, time_tag)
+            end
+
+            # Waits for processes to terminate. +timeout+ is the number of
+            # milliseconds we should wait. If set to nil, the call will block until
+            # a process terminates
+            #
+            # Returns a hash that maps deployment names to the Status
+            # object that represents their exit status.
+            def wait_termination(timeout = nil)
+                result, @terminated_worlds =
+                   terminated_worlds, Hash.new
+                result
+            end
+
+            # Requests to stop the given deployment
+            #
+            # The call does not block until the process has quit. You will have to
+            # call #wait_termination to wait for the process end.
+            def stop(world_name)
+                if w = worlds[world_name]
+                    w.kill
+                end
+            end
+
+            def dead_deployment(world_name, status = Status.new(:exit_code => 0))
+                if w = worlds.delete(world_name)
+                    terminated_worlds[w] = status
+                end
+            end
+        end
+    end
+end
+

--- a/bindings/ruby/lib/rock_gazebo/test.rb
+++ b/bindings/ruby/lib/rock_gazebo/test.rb
@@ -1,0 +1,58 @@
+# simplecov must be loaded FIRST. Only the files required after it gets loaded
+# will be profiled !!!
+if ENV['TEST_ENABLE_COVERAGE'] == '1'
+    begin
+        require 'simplecov'
+        SimpleCov.start
+    rescue LoadError
+        require 'rock_gazebo'
+        RockGazebo.warn "coverage is disabled because the 'simplecov' gem cannot be loaded"
+    rescue Exception => e
+        require 'rock_gazebo'
+        RockGazebo.warn "coverage is disabled: #{e.message}"
+    end
+end
+
+require 'flexmock/test_unit'
+require 'minitest/spec'
+
+if ENV['TEST_ENABLE_PRY'] != '0'
+    begin
+        require 'pry'
+    rescue Exception
+        RockGazebo.warn "debugging is disabled because the 'pry' gem cannot be loaded"
+    end
+end
+
+module RockGazebo
+    # This module is the common setup for all tests
+    #
+    # It should be included in the toplevel describe blocks
+    #
+    # @example
+    #   require 'rock_gazebo/test'
+    #   describe RockGazebo do
+    #     include RockGazebo::SelfTest
+    #   end
+    #
+    module SelfTest
+        if defined? FlexMock
+            include FlexMock::ArgumentTypes
+            include FlexMock::MockContainer
+        end
+
+        def setup
+            # Setup code for all the tests
+        end
+
+        def teardown
+            if defined? FlexMock
+                flexmock_teardown
+            end
+            super
+            # Teardown code for all the tests
+        end
+    end
+end
+
+Minitest::Test.include RockGazebo::SelfTest

--- a/bindings/ruby/test/data/multi_world.sdf
+++ b/bindings/ruby/test/data/multi_world.sdf
@@ -1,0 +1,4 @@
+<sdf version="1.5">
+    <world name="test0" />
+    <world name="test1" />
+</sdf>

--- a/bindings/ruby/test/data/no_world.sdf
+++ b/bindings/ruby/test/data/no_world.sdf
@@ -1,0 +1,2 @@
+<sdf version="1.5">
+</sdf>

--- a/bindings/ruby/test/data/test.world
+++ b/bindings/ruby/test/data/test.world
@@ -1,0 +1,6 @@
+<sdf version="1.5">
+    <world name="underwater">
+        <model name="flat_fish" />
+        <model name="oil_rig" />
+    </world>
+</sdf>

--- a/bindings/ruby/test/suite.rb
+++ b/bindings/ruby/test/suite.rb
@@ -1,0 +1,2 @@
+require './test/test_orogen_model_from_sdf_world'
+require './test/suite_syskit'

--- a/bindings/ruby/test/suite_syskit.rb
+++ b/bindings/ruby/test/suite_syskit.rb
@@ -1,0 +1,2 @@
+require './test/syskit/test_world_manager'
+require './test/syskit/test_world'

--- a/bindings/ruby/test/syskit/test_world.rb
+++ b/bindings/ruby/test/syskit/test_world.rb
@@ -1,0 +1,47 @@
+require 'rock_gazebo/test'
+require 'rock_gazebo/syskit'
+require 'orocos/test/ruby_tasks'
+
+module RockGazebo
+    module Syskit
+        describe World do
+            def data_dir
+                File.expand_path(File.join('..', 'data'), File.dirname(__FILE__))
+            end
+
+            attr_reader :world
+
+            before do
+                Orocos.load
+                manager = WorldManager.new
+                manager.register_world(File.join(data_dir, 'test.world'))
+                @world = manager.start('gazebo_world_underwater')
+            end
+
+            describe "spawn" do
+                it "sets the world as alive" do
+                    assert world.alive?
+                end
+            end
+
+            describe "wait_running" do
+                include Orocos::Test::RubyTasks
+
+                before do
+                    world.spawn
+                end
+
+                it "returns false if the world task is not available" do
+                    assert !world.wait_running
+                end
+
+                it "returns true as soon as the world task becomes available" do
+                    Orocos.initialize
+                    new_ruby_task_context 'gazebo:underwater'
+                    assert world.wait_running
+                end
+            end
+        end
+    end
+end
+

--- a/bindings/ruby/test/syskit/test_world_manager.rb
+++ b/bindings/ruby/test/syskit/test_world_manager.rb
@@ -1,0 +1,94 @@
+require 'rock_gazebo/test'
+require 'rock_gazebo/syskit'
+
+module RockGazebo
+    module Syskit
+        describe WorldManager do
+            def data_dir
+                File.expand_path(File.join('..', 'data'), File.dirname(__FILE__))
+            end
+
+            attr_reader :manager
+
+            before do
+                @manager = WorldManager.new
+                Orocos.load
+            end
+
+            describe "register_world" do
+                it "registers a world from a SDF file" do
+                    manager.register_world(File.join(data_dir, 'test.world'))
+                    # Note: the world name in the worldfile and the name of the
+                    # world file differ, and that is on purpose. We really want
+                    # to use the world name here
+                    manager.loader.deployment_model_from_name('gazebo_world_underwater')
+                end
+                it "bails out if multiple worlds are included and the world_name argument not" do
+                    assert_raises(ArgumentError) do
+                        manager.register_world(File.join(data_dir, 'multi_world.sdf'))
+                    end
+                end
+                it "uses world_name to disambiguate if there are multiple worlds" do
+                    manager.register_world(File.join(data_dir, 'multi_world.sdf'), 'test1')
+                    manager.loader.deployment_model_from_name("gazebo_world_test1")
+                end
+                it "bails out if no worlds are declared" do
+                    assert_raises(ArgumentError) do
+                        manager.register_world(File.join(data_dir, 'no_world.sdf'))
+                    end
+                end
+                it "bails out if a world matching world_name cannot be found" do
+                    assert_raises(ArgumentError) do
+                        manager.register_world(File.join(data_dir, 'test.world'), 'does_not_exist')
+                    end
+                end
+            end
+
+            describe "start" do
+                before do
+                    manager.register_world(File.join(data_dir, 'test.world'))
+                end
+
+                it "creates a World object to represent the tasks created by the rock_gazebo plugin" do
+                    world = manager.start("gazebo_world_underwater", "gazebo_world_underwater")
+                    assert_kind_of World, world
+                    assert_equal 'gazebo_world_underwater', world.name
+                end
+
+                it "bails out if there are name mappings" do
+                    assert_raises(WorldManager::NameMappingsForbidden) do
+                        manager.start("gazebo_world_underwater", "gazebo_world_underwater", 'gazebo:underwater' => 'test')
+                    end
+                end
+                
+                it "refuses to start the same world twice" do
+                    manager.start("gazebo_world_underwater", "gazebo_world_underwater")
+                    assert_raises(ArgumentError) do
+                        manager.start("gazebo_world_underwater", "gazebo_world_underwater")
+                    end
+                end
+            end
+
+            it "asynchronously reports on terminated worlds" do
+                manager.register_world(File.join(data_dir, 'test.world'))
+                w = manager.start("gazebo_world_underwater", "gazebo_world_underwater")
+                manager.dead_deployment("gazebo_world_underwater", (status = flexmock))
+                assert_equal Hash[w => status], manager.wait_termination
+                assert_equal Hash[], manager.wait_termination
+            end
+
+            describe "stop" do
+                before do
+                    manager.register_world(File.join(data_dir, 'test.world'))
+                end
+
+                it "calls kill on a registered world" do
+                    w = manager.start("gazebo_world_underwater", "gazebo_world_underwater")
+                    flexmock(w).should_receive(:kill).once
+                    manager.stop("gazebo_world_underwater")
+                end
+            end
+        end
+    end
+end
+

--- a/bindings/ruby/test/test_orogen_model_from_sdf_world.rb
+++ b/bindings/ruby/test/test_orogen_model_from_sdf_world.rb
@@ -1,0 +1,38 @@
+require 'rock_gazebo/test'
+require 'sdf'
+require 'rock_gazebo/orogen_model_from_sdf_world'
+
+module RockGazebo
+    describe 'orogen_model_from_sdf_world' do
+        before do
+            require 'orocos'
+            Orocos.load
+        end
+
+        def data_dir
+            File.expand_path('data', File.dirname(__FILE__))
+        end
+
+        it "creates a deployment that represents the rock_gazebo plugin behaviour" do
+            world = SDF::Root.load(File.join(data_dir, 'test.world')).each_world.first
+            model = RockGazebo.orogen_model_from_sdf_world('gazebo_world_test', world)
+            assert(world_task = model.find_task_by_name('gazebo:underwater'), "cannot find task gazebo:underwater in #{model}, tasks are: #{model.each_task.map(&:name).join(", ")}")
+            assert_equal 'rock_gazebo::WorldTask', world_task.task_model.name
+            assert(model_task = model.find_task_by_name('gazebo:underwater:flat_fish'))
+            assert_equal 'rock_gazebo::ModelTask', model_task.task_model.name
+            assert(model_task = model.find_task_by_name('gazebo:underwater:oil_rig'))
+            assert_equal 'rock_gazebo::ModelTask', model_task.task_model.name
+        end
+
+        it "allows to override the task's periodicity" do
+            world = SDF::Root.load(File.join(data_dir, 'test.world')).each_world.first
+            expected_period = 0.1
+            model = RockGazebo.orogen_model_from_sdf_world('gazebo_world_test', world, period: expected_period)
+
+            %w{gazebo:underwater gazebo:underwater:flat_fish gazebo:underwater:oil_rig}.each do |task_name|
+                task = model.find_task_by_name(task_name)
+                assert_in_delta expected_period, task.period, 0.00001
+            end
+        end
+    end
+end


### PR DESCRIPTION
This bits allow to use the Rock/Gazebo integration in Syskit by adding the following in the robot configuration:

```
Syskit.conf.use_gazebo_world 'path', 'to', 'world', 'file'
```

This generates a bunch of deployments of the same type (all ModelTask), so one also needs to explicitely do deployment selection (based on the task's names) in the profiles, though.
