### PR TITLE
Create the rock-gazebo-viz script

### DIFF
--- a/bindings/ruby/CMakeLists.txt
+++ b/bindings/ruby/CMakeLists.txt
@@ -1,2 +1,3 @@
 rock_add_ruby_package(rock_gazebo)
+rock_add_ruby_package(rock)
 

--- a/bindings/ruby/CMakeLists.txt
+++ b/bindings/ruby/CMakeLists.txt
@@ -1,3 +1,7 @@
 rock_add_ruby_package(rock_gazebo)
 rock_add_ruby_package(rock)
+if (rock_AVAILABLE)
+    install(PROGRAMS bin/rock-gazebo-viz bin/rock-gazebo-run
+        DESTINATION bin)
+endif()
 

--- a/bindings/ruby/bin/rock-gazebo-run
+++ b/bindings/ruby/bin/rock-gazebo-run
@@ -1,0 +1,5 @@
+#! /usr/bin/env ruby
+require 'rock/gazebo'
+Bundles.load
+Process.exec(Hash['GAZEBO_MODEL_PATH' => Rock::Gazebo.model_path.join(":")],
+             *ARGV)

--- a/bindings/ruby/bin/rock-gazebo-viz
+++ b/bindings/ruby/bin/rock-gazebo-viz
@@ -27,6 +27,7 @@ require 'rock/gazebo'
 Rock::Gazebo.initialize
 
 vizkit3d = Vizkit.vizkit3d_widget
+vizkit3d.transformer = false
 conf = Transformer::Configuration.new
 conf.load_sdf(path)
 vizkit3d.apply_transformer_configuration(conf)

--- a/bindings/ruby/bin/rock-gazebo-viz
+++ b/bindings/ruby/bin/rock-gazebo-viz
@@ -1,0 +1,77 @@
+#! /usr/bin/env ruby
+require 'vizkit'
+require 'transformer'
+require 'transformer/sdf'
+
+start = true
+parser = OptionParser.new do |opt|
+    opt.banner = "rock-gazebo-viz [OPTIONS] worldfile"
+
+    opt.on '--host HOSTNAME', String, 'the host we should connect to to find the rock_gazebo tasks' do |host|
+        Orocos::CORBA.name_service.ip = host
+    end
+
+    opt.on '--[no-]start', 'do not start the rock_gazebo::ModelTask we need (the default is to start them automatically)' do |host|
+        start = false
+    end
+end
+
+path = parser.parse(ARGV)
+if path.size != 1
+    STDERR.puts parser
+    exit 1
+end
+path = path.first
+
+require 'rock/gazebo'
+Rock::Gazebo.initialize
+
+vizkit3d = Vizkit.vizkit3d_widget
+conf = Transformer::Configuration.new
+conf.load_sdf(path)
+vizkit3d.apply_transformer_configuration(conf)
+
+sdf = SDF::Root.load(path)
+sdf.each_model(recursive: true) do |model|
+    model_viz = Vizkit.default_loader.RobotVisualization
+    model_viz.enabled = false
+
+    model_only = model.make_root
+    model_viz.loadFromString(model_only.xml.to_s, 'sdf', File.dirname(path))
+    model_viz.frame = model.name
+
+    task_name = "gazebo:#{model.full_name.gsub('::', ':')}"
+    task_proxy = Orocos::Async.proxy task_name
+    if start
+        task_proxy.on_reachable do
+            begin
+                if task_proxy.rtt_state == :PRE_OPERATIONAL
+                    task_proxy.configure
+                end
+
+                if task_proxy.rtt_state == :STOPPED
+                    task_proxy.start
+                end
+
+                state = task_proxy.rtt_state
+                if state != :RUNNING
+                    STDERR.puts "could not start #{task_name} (currently in state #{state})"
+                end
+            rescue Exception => e
+                STDERR.puts "failed to start #{task_name}: #{e}"
+            end
+        end
+    end
+    trsf = conf.dynamic_transform "#{task_name}.pose_samples", model.name => (model.parent.full_name || 'osg_world')
+    vizkit3d.listen_to_transformation_producer(trsf)
+    joints_out = task_proxy.port "joints_samples"
+
+    joints_out.on_data do |sample|
+        model_viz.updateData(sample)
+    end
+    joints_out.once_on_data do |sample|
+        model_viz.enabled = true
+    end
+end
+
+Vizkit.exec

--- a/bindings/ruby/lib/rock/gazebo.rb
+++ b/bindings/ruby/lib/rock/gazebo.rb
@@ -1,0 +1,20 @@
+require 'rock/bundles'
+module Rock
+    module Gazebo
+        def self.model_path
+            Bundles.find_dirs('data','gazebo','models', :all => true, :order => :specific_first) +
+                (ENV['GAZEBO_MODEL_PATH']||"").split(':') +
+                [File.join(Dir.home, '.gazebo', 'models')]
+        end
+
+        def self.initialize
+            Bundles.load
+
+            require 'sdf'
+            model_path = self.model_path
+            SDF::XML.model_path = model_path
+            ENV['GAZEBO_MODEL_PATH'] = model_path.join(":")
+        end
+    end
+end
+

--- a/src/rock-gazebo.in
+++ b/src/rock-gazebo.in
@@ -1,12 +1,3 @@
-#! /usr/bin/ruby
-require 'rock/bundles'
+#! /bin/sh
 
-Bundles.load
-
-model_path =
-    Bundles.find_dirs('data','gazebo','models', :all => true, :order => :specific_first).join(":") +
-    (ENV['GAZEBO_MODEL_PATH']||"")
-
-Process.exec(
-    Hash['GAZEBO_MODEL_PATH' => model_path],
-    "gazebo",'-s',"@CMAKE_INSTALL_PREFIX@/lib/librock_gazebo.so",*ARGV)
+rock-gazebo-run gazebo -s "@CMAKE_INSTALL_PREFIX@/lib/librock_gazebo.so" "$@"

--- a/src/rock-gazebo.in
+++ b/src/rock-gazebo.in
@@ -1,14 +1,12 @@
 #! /usr/bin/ruby
 require 'rock/bundles'
-require 'optparse'
-
-options = OptionParser.new
-args = options.parse(ARGV)
-world_file = args.shift
 
 Bundles.load
 
-ENV['GAZEBO_MODEL_PATH']=Bundles.find_dirs('data','gazebo','models', :all => true,
-    :order => :specific_first).join(":")+(ENV['GAZEBO_MODEL_PATH']||"")
+model_path =
+    Bundles.find_dirs('data','gazebo','models', :all => true, :order => :specific_first).join(":") +
+    (ENV['GAZEBO_MODEL_PATH']||"")
 
-Process.exec("gazebo","--verbose","-s","@CMAKE_INSTALL_PREFIX@/lib/librock_gazebo.so","#{world_file}")
+Process.exec(
+    Hash['GAZEBO_MODEL_PATH' => model_path],
+    "gazebo",'-s',"@CMAKE_INSTALL_PREFIX@/lib/librock_gazebo.so",*ARGV)

--- a/src/rock-gzserver.in
+++ b/src/rock-gzserver.in
@@ -1,12 +1,3 @@
-#! /usr/bin/ruby
-require 'rock/bundles'
+#! /bin/sh
 
-Bundles.load
-
-model_path =
-    Bundles.find_dirs('data','gazebo','models', :all => true, :order => :specific_first).join(":") +
-    (ENV['GAZEBO_MODEL_PATH']||"")
-
-Process.exec(
-    Hash['GAZEBO_MODEL_PATH' => model_path],
-    "gzserver",'-s',"@CMAKE_INSTALL_PREFIX@/lib/librock_gazebo.so",*ARGV)
+rock-gazebo-run gazebo -s "@CMAKE_INSTALL_PREFIX@/lib/librock_gazebo.so" "$@"

--- a/src/rock-gzserver.in
+++ b/src/rock-gzserver.in
@@ -1,14 +1,12 @@
 #! /usr/bin/ruby
 require 'rock/bundles'
-require 'optparse'
-
-options = OptionParser.new
-args = options.parse(ARGV)
-world_file = args.shift
 
 Bundles.load
 
-ENV['GAZEBO_MODEL_PATH']=Bundles.find_dirs('data','gazebo','models', :all => true,
-    :order => :specific_first).join(":")+(ENV['GAZEBO_MODEL_PATH']||"")
+model_path =
+    Bundles.find_dirs('data','gazebo','models', :all => true, :order => :specific_first).join(":") +
+    (ENV['GAZEBO_MODEL_PATH']||"")
 
-Process.exec("gzserver","--verbose","-s","@CMAKE_INSTALL_PREFIX@/lib/librock_gazebo.so","#{world_file}")
+Process.exec(
+    Hash['GAZEBO_MODEL_PATH' => model_path],
+    "gzserver",'-s',"@CMAKE_INSTALL_PREFIX@/lib/librock_gazebo.so",*ARGV)


### PR DESCRIPTION
This script allows to display the state of a gazebo simulation simply by providing the world file.

It depends on a bunch of fixes in the SDF integration:
- https://github.com/Brazilian-Institute-of-Robotics/control-kdl_parser/pull/2
- https://github.com/Brazilian-Institute-of-Robotics/gui-robot_model/pull/2
- https://github.com/Brazilian-Institute-of-Robotics/gui-robot_model/pull/4
- https://github.com/Brazilian-Institute-of-Robotics/simulation-orogen-rock_gazebo/pull/7
